### PR TITLE
Enable env-based index config for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,20 @@ This project demonstrates an Algolia search implementation with an Express.js ba
 ## Setup
 
 1. Copy `.env.example` to `.env` and fill in your Algolia credentials.
-2. Install dependencies (requires internet access):
+2. Copy `client/env.example.js` to `client/env.js` and adjust the index name and replicas if needed.
+3. Install dependencies (requires internet access):
    ```bash
    npm install
    ```
-3. Start the server:
+4. Start the server:
    ```bash
    node server/index.js
    ```
-4. Serve the `client/` folder (for example with `npx serve client`). The frontend proxies search requests to the backend at `/search` and `/facet`.
+5. Serve the `client/` folder (for example with `npx serve client`). The frontend proxies search requests to the backend at `/search` and `/facet`.
 
 ## Notes
 
 - Two Algolia replica indices named `products_price_asc` and `products_price_desc` are expected for sorting by price.
 - The example fetches the client IP via `https://api.ipify.org`; adjust as needed or remove if running offline.
+- Frontend configuration is read from `client/env.js` so index names can be changed without modifying `index.html`.
 

--- a/client/env.example.js
+++ b/client/env.example.js
@@ -1,0 +1,5 @@
+window.ENV = {
+  INDEX_NAME: 'products',
+  REPLICA_ASC: 'products_price_asc',
+  REPLICA_DESC: 'products_price_desc'
+};

--- a/client/index.html
+++ b/client/index.html
@@ -18,6 +18,7 @@
   <div id="hits"></div>
   <div id="pagination"></div>
 
+  <script src="env.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4"></script>
   <script>
     let userIP = '';
@@ -52,8 +53,12 @@
       }
     };
 
+    const INDEX_NAME = (window.ENV && window.ENV.INDEX_NAME) || 'products';
+    const REPLICA_ASC = (window.ENV && window.ENV.REPLICA_ASC) || 'products_price_asc';
+    const REPLICA_DESC = (window.ENV && window.ENV.REPLICA_DESC) || 'products_price_desc';
+
     const search = instantsearch({
-      indexName: 'products',
+      indexName: INDEX_NAME,
       searchClient
     });
 
@@ -65,8 +70,8 @@
       instantsearch.widgets.sortBy({
         container: '#sort-by',
         items: [
-          { label: 'Price low to high', value: 'products_price_asc' },
-          { label: 'Price high to low', value: 'products_price_desc' }
+          { label: 'Price low to high', value: REPLICA_ASC },
+          { label: 'Price high to low', value: REPLICA_DESC }
         ]
       }),
       instantsearch.widgets.refinementList({


### PR DESCRIPTION
## Summary
- allow customizing index name and replica indices from an `env.js` file
- provide `client/env.example.js` for easy configuration
- document new step in setup instructions

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b905f489c8327805c540d6e1a44d3