### PR TITLE
Fix missing dependencies for OpenTelemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
     "algoliasearch": "^4.17.2",
     "dotenv": "^16.0.3"
     ,"@honeycombio/opentelemetry-node": "^0.6.0",
-    "@opentelemetry/api": "^1.6.0"
+    "@opentelemetry/api": "^1.6.0",
+    "@opentelemetry/sdk-node": "^1.6.0",
+    "@opentelemetry/auto-instrumentations-node": "^1.6.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^1.6.0",
+    "@opentelemetry/resources": "^1.6.0",
+    "@opentelemetry/semantic-conventions": "^1.6.0"
   }
 }


### PR DESCRIPTION
## Summary
- include OpenTelemetry packages that are required by `server/tracing.js`

## Testing
- `npm test` *(fails: "Error: no test specified")*
- `npm install` *(fails: npm ERR! 403 Forbidden - GET https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_685c0079c2348327a3b50ef74bef13db