### PR TITLE
Align OpenTelemetry packages with Honeycomb distro

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,13 +15,10 @@
     "express": "^4.18.2",
     "cors": "^2.8.5",
     "algoliasearch": "^4.17.2",
-    "dotenv": "^16.0.3"
-    ,"@honeycombio/opentelemetry-node": "^0.6.0",
-    "@opentelemetry/api": "^1.6.0",
-    "@opentelemetry/sdk-node": "^2",
-    "@opentelemetry/auto-instrumentations-node": "^0.60",
-    "@opentelemetry/exporter-trace-otlp-http": "^2",
-    "@opentelemetry/resources": "^1.6.0",
-    "@opentelemetry/semantic-conventions": "^1.6.0"
+    "dotenv": "^16.0.3",
+    "@honeycombio/opentelemetry-node": "^0.6",
+    "@opentelemetry/sdk-node": "^1",
+    "@opentelemetry/exporter-trace-otlp-http": "^1",
+    "@opentelemetry/auto-instrumentations-node": "~0.43"
   }
 }


### PR DESCRIPTION
## Summary
- align OpenTelemetry packages with Honeycomb's 0.6.x distro

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c2e1bff188327a34f71a0df3e1595