### PR TITLE
Add bot detection middleware

### DIFF
--- a/server/authBotMiddleware.js
+++ b/server/authBotMiddleware.js
@@ -1,0 +1,18 @@
+const hitTable = new Map();   // keeps per-client counters
+
+module.exports = (req, res, next) => {
+  const span = honeycomb.startSpan({ name: 'botAuth' });
+
+  const key   = req.headers['x-user-token'] || req.ip;
+  const hits  = hitTable.get(key) ?? 0;
+  hitTable.set(key, hits + 1);
+
+  const delay = Math.min(20 * hits, 450);      // delay grows with traffic
+  span.addField('auth.hit_count', hits);
+  span.addField('auth.delay_ms', delay);
+
+  setTimeout(() => {
+    span.end();
+    next();          // hand control to the next middleware/route handler
+  }, delay);
+};

--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,7 @@ const express = require('express');
 const cors = require('cors');
 const algoliasearch = require('algoliasearch');
 const path = require('path');
+const botAuth  = require('./authBotMiddleware');
 // The OpenTelemetry API is used directly for manual spans
 const { trace } = require('@opentelemetry/api');
 
@@ -56,7 +57,7 @@ client.initIndex(indexName)
   .catch(err => console.error('Algolia connection error:', err.message));
 
 // Wrap search endpoint in a span to capture Algolia request latency
-app.post('/search', async (req, res) => {
+app.post('/search', botAuth, async (req, res) => {
   const requests = req.body.requests || [];
   const userIp = req.headers['x-forwarded-for'] || req.ip;
 


### PR DESCRIPTION
## Summary
- implement authBotMiddleware.js for simulating bot detection delays
- wire the middleware into server startup and search endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875f51f8fd08327bf5e087f6b1f7ca8