### PR TITLE
Fix bot middleware to use OpenTelemetry trace API

### DIFF
--- a/server/authBotMiddleware.js
+++ b/server/authBotMiddleware.js
@@ -1,18 +1,22 @@
+const { trace, context } = require('@opentelemetry/api');
+
 const hitTable = new Map();   // keeps per-client counters
 
 module.exports = (req, res, next) => {
-  const span = honeycomb.startSpan({ name: 'botAuth' });
+  const span = trace.startSpan('botAuth');
 
   const key   = req.headers['x-user-token'] || req.ip;
   const hits  = hitTable.get(key) ?? 0;
   hitTable.set(key, hits + 1);
 
   const delay = Math.min(20 * hits, 450);      // delay grows with traffic
-  span.addField('auth.hit_count', hits);
-  span.addField('auth.delay_ms', delay);
+  span.setAttribute('auth.hit_count', hits);
+  span.setAttribute('auth.delay_ms', delay);
 
-  setTimeout(() => {
-    span.end();
-    next();          // hand control to the next middleware/route handler
-  }, delay);
+  context.with(trace.setSpan(context.active(), span), () => {
+    setTimeout(() => {
+      span.end();
+      next();          // hand control to the next middleware/route handler
+    }, delay);
+  });
 };


### PR DESCRIPTION
## Summary
- use `trace.startSpan` from OpenTelemetry in bot detection middleware
- set attributes using the OpenTelemetry API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68767d09f9c48327b55863a4c5cdc518